### PR TITLE
"View job run" link in Claude's comment points to an unrelated, older run

### DIFF
--- a/src/entrypoints/update-comment-link.ts
+++ b/src/entrypoints/update-comment-link.ts
@@ -32,7 +32,7 @@ async function run() {
     const client = createClient(githubToken);
 
     const serverUrl = GITEA_SERVER_URL;
-    const jobUrl = `${serverUrl}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_NUMBER}`;
+    const jobUrl = `${serverUrl}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
     let comment;
     let isPRReviewComment = false;

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -55,7 +55,7 @@ export function parseGitHubContext(): ParsedGitHubContext {
   }
 
   const commonFields = {
-    runId: process.env.GITHUB_RUN_NUMBER!,
+    runId: process.env.GITHUB_RUN_ID!,
     eventName: context.eventName,
     eventAction: context.payload.action,
     repository: {


### PR DESCRIPTION
## Summary

After Claude responds to an `@claude` mention in a PR, the *"View job run"* link appended to the tracking comment points to a **different, older workflow run** — usually one from a completely unrelated PR — instead of the run that produced the comment.

## Environment

- Action version: `v1.0.20`
- Gitea: `1.26.2`
- `act_runner`: `0.6.1`

## Reproduction

1. Trigger the action by commenting `@claude testing` in any PR.
2. The current run lives at, e.g., `https://git.example.com/owner/repo/actions/runs/1829`.
3. Wait for Claude's comment update; it contains a `View job run` link.
4. Click the link → you are taken to `runs/1822` (or similar), a real but **unrelated, older** workflow run.

## Root cause

`src/entrypoints/update-comment-link.ts` builds the URL using the wrong environment variable:

```ts
const jobUrl = `${serverUrl}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_NUMBER}`;
```

`GITHUB_RUN_NUMBER` is the per-workflow-file *sequence counter* (run #1, #2, #3, …) — not the globally unique workflow-run identifier that Gitea (and GitHub) uses in `/actions/runs/<id>` URLs. On both Gitea and GitHub the URL path expects the **run ID** (`github.run_id`), not the run number.

To make the issue worse, `GITHUB_RUN_NUMBER` is not even explicitly populated by the action — only `GITHUB_RUN_ID` is set in `action.yml`:

```yaml
- name: Update comment with job link
  env:
    GITHUB_RUN_ID: ${{ github.run_id }}
    # GITHUB_RUN_NUMBER is never set here
```

So the value that ends up in the URL is whatever the runner happens to expose as `GITHUB_RUN_NUMBER`, which on Gitea diverges noticeably from the run ID — producing a real but stale URL that happens to resolve to *some* prior run.

## Suggested fix

Use `GITHUB_RUN_ID` — the variable that `action.yml` already passes through correctly:

```diff
-    const jobUrl = `${serverUrl}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_NUMBER}`;
+    const jobUrl = `${serverUrl}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
```

This is also the documented variable for building Actions run URLs in the upstream GitHub Actions reference — and matches what `actions/checkout` and other first-party actions use.

## Verification

After the fix, the link in Claude's comment resolves to the exact run that produced the comment, matching the URL bar when the user navigated to the workflow from the Actions tab.