### PR TITLE
chore: bump Claude Code version to 2.1.173

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,6 +29,5 @@ jobs:
             - Documentation consistency: Verify that README.md and other documentation files are updated to reflect any code changes (especially new inputs, features, or configuration options)
 
             Be constructive and specific in your feedback. Give inline comments where applicable.
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY && secrets.ANTHROPIC_API_KEY || secrets.CLAUDE_CREDENTIALS }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CREDENTIALS }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_tools: "mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,8 +33,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY && secrets.ANTHROPIC_API_KEY || secrets.CLAUDE_CREDENTIALS }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CREDENTIALS }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_tools: "Bash(bun install),Bash(bun test:*),Bash(bun run format),Bash(bun typecheck)"
           custom_instructions: "You have also been granted tools for editing files and running bun commands (install, run, test, typecheck) for testing your changes: bun install, bun test, bun run format, bun typecheck."
           model: "claude-opus-4-20250514"

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -103,5 +103,4 @@ jobs:
           allowed_tools: "Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__search_issues,mcp__github__list_issues"
           mcp_config: /tmp/mcp-config/mcp-servers.json
           timeout_minutes: "5"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY && secrets.ANTHROPIC_API_KEY || secrets.CLAUDE_CREDENTIALS }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CREDENTIALS }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/test-base-action.yml
+++ b/.github/workflows/test-base-action.yml
@@ -23,8 +23,7 @@ jobs:
         uses: ./base-action
         with:
           prompt: ${{ github.event.inputs.test_prompt || 'List the files in the current directory starting with "package"' }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY && secrets.ANTHROPIC_API_KEY || secrets.CLAUDE_CREDENTIALS }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CREDENTIALS }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_tools: "LS,Read"
           timeout_minutes: "3"
 
@@ -82,8 +81,7 @@ jobs:
         uses: ./base-action
         with:
           prompt_file: "test-prompt.txt"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY && secrets.ANTHROPIC_API_KEY || secrets.CLAUDE_CREDENTIALS }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CREDENTIALS }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_tools: "LS,Read"
           timeout_minutes: "3"
 

--- a/.github/workflows/test-base-action.yml
+++ b/.github/workflows/test-base-action.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
     inputs:
       test_prompt:

--- a/.github/workflows/test-claude-env.yml
+++ b/.github/workflows/test-claude-env.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-claude-env.yml
+++ b/.github/workflows/test-claude-env.yml
@@ -19,8 +19,7 @@ jobs:
         with:
           prompt: |
             Use the Bash tool to run: echo "VAR1: $VAR1" && echo "VAR2: $VAR2"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY && secrets.ANTHROPIC_API_KEY || secrets.CLAUDE_CREDENTIALS }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CREDENTIALS }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_env: |
             # This is a comment
             VAR1: value1

--- a/.github/workflows/test-custom-executables.yml
+++ b/.github/workflows/test-custom-executables.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-custom-executables.yml
+++ b/.github/workflows/test-custom-executables.yml
@@ -49,8 +49,7 @@ jobs:
         with:
           prompt: |
             List the files in the current directory starting with "package"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY && secrets.ANTHROPIC_API_KEY || secrets.CLAUDE_CREDENTIALS }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CREDENTIALS }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_claude_code_executable: /home/runner/.local/bin/claude
           path_to_bun_executable: /home/runner/.bun/bin/bun
           allowed_tools: "LS,Read"

--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -28,8 +28,7 @@ jobs:
         id: claude-test
         with:
           prompt: "List all available tools"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY && secrets.ANTHROPIC_API_KEY || secrets.CLAUDE_CREDENTIALS }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CREDENTIALS }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         env:
           # Change to test directory so it finds .mcp.json
           CLAUDE_WORKING_DIR: ${{ github.workspace }}/base-action/test/mcp-test
@@ -110,8 +109,7 @@ jobs:
         id: claude-config-test
         with:
           prompt: "List all available tools"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY && secrets.ANTHROPIC_API_KEY || secrets.CLAUDE_CREDENTIALS }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CREDENTIALS }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           mcp_config: '{"mcpServers":{"test-server":{"type":"stdio","command":"bun","args":["simple-mcp-server.ts"],"env":{}}}}'
         env:
           # Change to test directory so bun can find the MCP server script

--- a/.github/workflows/test-settings.yml
+++ b/.github/workflows/test-settings.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-settings.yml
+++ b/.github/workflows/test-settings.yml
@@ -19,8 +19,7 @@ jobs:
         with:
           prompt: |
             Use Bash to echo "Hello from settings test"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY && secrets.ANTHROPIC_API_KEY || secrets.CLAUDE_CREDENTIALS }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CREDENTIALS }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: |
             {
               "permissions": {
@@ -70,8 +69,7 @@ jobs:
         with:
           prompt: |
             Use Bash to echo "This should not work"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY && secrets.ANTHROPIC_API_KEY || secrets.CLAUDE_CREDENTIALS }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CREDENTIALS }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: |
             {
               "permissions": {
@@ -114,8 +112,7 @@ jobs:
         with:
           prompt: |
             Use Bash to echo "Hello from settings file test"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY && secrets.ANTHROPIC_API_KEY || secrets.CLAUDE_CREDENTIALS }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CREDENTIALS }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: "test-settings.json"
           timeout_minutes: "2"
 
@@ -170,8 +167,7 @@ jobs:
         with:
           prompt: |
             Use Bash to echo "This should not work from file"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY && secrets.ANTHROPIC_API_KEY || secrets.CLAUDE_CREDENTIALS }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CREDENTIALS }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: "test-settings.json"
           timeout_minutes: "2"
 

--- a/README.md
+++ b/README.md
@@ -54,24 +54,24 @@ jobs:
 
 ## Inputs
 
-| Input                 | Description                                                                                                                  | Required | Default                |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------- | ---------------------- |
-| `anthropic_api_key`   | Anthropic API key (required for direct API, not needed for Bedrock/Vertex) | No\*     | -                      |
-| `claude_code_oauth_token` | Claude Code OAuth token (alternative to anthropic_api_key) | No       | -                      |
-| `direct_prompt`       | Direct prompt for Claude to execute automatically without needing a trigger (for automated workflows)                        | No       | -                      |
-| `timeout_minutes`     | Timeout in minutes for execution                                                                                             | No       | `30`                   |
-| `gitea_token`         | Gitea token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!**          | No       | -                      |
-| `model`               | Model to use (provider-specific format required for Bedrock/Vertex)                                                          | No       | -                      |
-| `anthropic_model`     | **DEPRECATED**: Use `model` instead. Kept for backward compatibility.                                                        | No       | -                      |
-| `use_bedrock`         | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                                  | No       | `false`                |
-| `use_vertex`          | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                                | No       | `false`                |
-| `allowed_tools`       | Additional tools for Claude to use (the base GitHub tools will always be included)                                           | No       | ""                     |
-| `disallowed_tools`    | Tools that Claude should never use                                                                                           | No       | ""                     |
-| `custom_instructions` | Additional custom instructions to include in the prompt for Claude                                                           | No       | ""                     |
-| `assignee_trigger`    | The assignee username that triggers the action (e.g. @claude). Only used for issue and PR assignment                                | No       | -                      |
-| `trigger_phrase`      | The trigger phrase to look for in comments, issue/PR bodies, and issue titles                                                | No       | `@claude`              |
-| `claude_git_name`     | Git user.name for commits made by Claude                                                                                     | No       | `Claude`               |
-| `claude_git_email`    | Git user.email for commits made by Claude                                                                                    | No       | `claude@anthropic.com` |
+| Input                     | Description                                                                                                         | Required | Default                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------- | ---------------------- |
+| `anthropic_api_key`       | Anthropic API key (required for direct API, not needed for Bedrock/Vertex)                                          | No\*     | -                      |
+| `claude_code_oauth_token` | Claude Code OAuth token (alternative to anthropic_api_key)                                                          | No       | -                      |
+| `direct_prompt`           | Direct prompt for Claude to execute automatically without needing a trigger (for automated workflows)               | No       | -                      |
+| `timeout_minutes`         | Timeout in minutes for execution                                                                                    | No       | `30`                   |
+| `gitea_token`             | Gitea token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!** | No       | -                      |
+| `model`                   | Model to use (provider-specific format required for Bedrock/Vertex)                                                 | No       | -                      |
+| `anthropic_model`         | **DEPRECATED**: Use `model` instead. Kept for backward compatibility.                                               | No       | -                      |
+| `use_bedrock`             | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                         | No       | `false`                |
+| `use_vertex`              | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                       | No       | `false`                |
+| `allowed_tools`           | Additional tools for Claude to use (the base GitHub tools will always be included)                                  | No       | ""                     |
+| `disallowed_tools`        | Tools that Claude should never use                                                                                  | No       | ""                     |
+| `custom_instructions`     | Additional custom instructions to include in the prompt for Claude                                                  | No       | ""                     |
+| `assignee_trigger`        | The assignee username that triggers the action (e.g. @claude). Only used for issue and PR assignment                | No       | -                      |
+| `trigger_phrase`          | The trigger phrase to look for in comments, issue/PR bodies, and issue titles                                       | No       | `@claude`              |
+| `claude_git_name`         | Git user.name for commits made by Claude                                                                            | No       | `Claude`               |
+| `claude_git_email`        | Git user.email for commits made by Claude                                                                           | No       | `claude@anthropic.com` |
 
 \*Required when using direct Anthropic API (default and when not using Bedrock or Vertex)
 
@@ -102,6 +102,7 @@ When running Gitea in containers, the action may generate links using internal c
 ```
 
 **How it works:**
+
 - The action first checks for `GITEA_SERVER_URL` (user-configurable)
 - Falls back to `GITHUB_SERVER_URL` (automatically set by Gitea Actions)
 - Uses `https://github.com` as final fallback
@@ -570,9 +571,11 @@ You can authenticate with Claude using any of these methods:
 If you have access to [Claude Code](https://claude.ai/code), you can use OAuth authentication instead of an API key:
 
 1. **Generate OAuth Token**: run the following command and follow instructions:
+
    ```
    claude setup-token
    ```
+
    This will generate an OAuth token that you can use for authentication.
 
 2. **Add Token to Repository**: Add the generated token as a repository secret named `CLAUDE_CODE_OAUTH_TOKEN`.

--- a/action.yml
+++ b/action.yml
@@ -189,7 +189,6 @@ runs:
           echo "$CLAUDE_DIR" >> "$GITHUB_PATH"
         fi
     # TODO pass claude_code_executable as input and use it here
-
     - name: Run Claude Code
       id: claude-code
       if: steps.prepare.outputs.contains_trigger == 'true'
@@ -225,7 +224,7 @@ runs:
         USE_VERTEX: ${{ inputs.use_vertex }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
         CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
-        
+
         # New settings support
         SETTINGS: ${{ inputs.settings }}
         SYSTEM_PROMPT: ${{ inputs.system_prompt }}

--- a/action.yml
+++ b/action.yml
@@ -173,26 +173,10 @@ runs:
         GITEA_API_URL: ${{ env.GITHUB_SERVER_URL }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
 
-    - name: Install Claude
-      if: steps.prepare.outputs.contains_trigger == 'true'
-      shell: bash
-      run: |
-        # Install Claude Code if no custom executable is provided
-        if [ -z "${{ inputs.path_to_claude_code_executable }}" ]; then
-          echo "Installing Claude Code..."
-          curl -fsSL https://claude.ai/install.sh | bash -s 2.1.173
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        else
-          echo "Using custom Claude Code executable: ${{ inputs.path_to_claude_code_executable }}"
-          # Add the directory containing the custom executable to PATH
-          CLAUDE_DIR=$(dirname "${{ inputs.path_to_claude_code_executable }}")
-          echo "$CLAUDE_DIR" >> "$GITHUB_PATH"
-        fi
-    # TODO pass claude_code_executable as input and use it here
     - name: Run Claude Code
       id: claude-code
       if: steps.prepare.outputs.contains_trigger == 'true'
-      uses: anthropics/claude-code-base-action@v0.0.63
+      uses: markwylde/claude-code-gitea-action/base-action@6f6b9c0489623e97cff4f10bde3283e8fb6ba856
       with:
         prompt_file: /tmp/claude-prompts/claude-prompt.txt
         allowed_tools: ${{ env.ALLOWED_TOOLS }}
@@ -203,6 +187,7 @@ runs:
         mcp_config: ${{ steps.prepare.outputs.mcp_config }}
         use_bedrock: ${{ inputs.use_bedrock }}
         use_vertex: ${{ inputs.use_vertex }}
+        path_to_claude_code_executable: ${{ inputs.path_to_claude_code_executable }}
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         settings: ${{ inputs.settings }}

--- a/action.yml
+++ b/action.yml
@@ -180,7 +180,7 @@ runs:
         # Install Claude Code if no custom executable is provided
         if [ -z "${{ inputs.path_to_claude_code_executable }}" ]; then
           echo "Installing Claude Code..."
-          curl -fsSL https://claude.ai/install.sh | bash -s 1.0.117
+          curl -fsSL https://claude.ai/install.sh | bash -s 2.1.173
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         else
           echo "Using custom Claude Code executable: ${{ inputs.path_to_claude_code_executable }}"

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -115,7 +115,7 @@ runs:
 
     - name: Install Claude Code
       shell: bash
-      run: bun install -g @anthropic-ai/claude-code@1.0.61
+      run: bun install -g @anthropic-ai/claude-code@2.1.173
 
     - name: Run Claude Code Action
       shell: bash

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -61,6 +61,10 @@ inputs:
     description: "Timeout in minutes for Claude Code execution"
     required: false
     default: "10"
+  path_to_claude_code_executable:
+    description: "Path to a custom Claude Code executable to use instead of installing"
+    required: false
+    default: ""
 
   # Authentication settings
   anthropic_api_key:
@@ -114,10 +118,20 @@ runs:
         bun install
 
     - name: Install Claude Code
+      if: inputs.path_to_claude_code_executable == ''
       shell: bash
       run: |
         curl -fsSL https://claude.ai/install.sh | bash -s 2.1.173
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+    - name: Use custom Claude Code executable
+      if: inputs.path_to_claude_code_executable != ''
+      shell: bash
+      env:
+        CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
+      run: |
+        echo "Using custom Claude Code executable: $CLAUDE_CODE_EXECUTABLE"
+        echo "$(dirname "$CLAUDE_CODE_EXECUTABLE")" >> "$GITHUB_PATH"
 
     - name: Run Claude Code Action
       shell: bash

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -115,7 +115,9 @@ runs:
 
     - name: Install Claude Code
       shell: bash
-      run: bun install -g @anthropic-ai/claude-code@2.1.173
+      run: |
+        curl -fsSL https://claude.ai/install.sh | bash -s 2.1.173
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
     - name: Run Claude Code Action
       shell: bash

--- a/examples/gitea-custom-url.yml
+++ b/examples/gitea-custom-url.yml
@@ -18,6 +18,6 @@ jobs:
           # Set this to your public Gitea URL to override the internal container URL
           # This ensures that links in comments point to the correct public URL
           GITEA_SERVER_URL: https://gitea.example.com
-          
+
           # Note: GITHUB_SERVER_URL is automatically set by Gitea Actions to the internal URL
           # but it will be overridden by GITEA_SERVER_URL if set above

--- a/src/github/validation/trigger.ts
+++ b/src/github/validation/trigger.ts
@@ -27,7 +27,10 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
   }
 
   // Check for assignee trigger
-  if (isIssuesEvent(context) && (context.eventAction === "assigned" || context.eventAction === "opened")) {
+  if (
+    isIssuesEvent(context) &&
+    (context.eventAction === "assigned" || context.eventAction === "opened")
+  ) {
     // Remove @ symbol from assignee_trigger if present
     let triggerUser = assigneeTrigger?.replace(/^@/, "") || "";
     const assigneeUsername = context.payload.issue.assignee?.login || "";

--- a/test/branch-cleanup.test.ts
+++ b/test/branch-cleanup.test.ts
@@ -97,7 +97,9 @@ describe("checkAndDeleteEmptyBranch", () => {
   });
 
   test("falls back to branch link when API call fails", async () => {
-    const client = createMockClient({ error: Object.assign(new Error("boom"), { status: 500 }) });
+    const client = createMockClient({
+      error: Object.assign(new Error("boom"), { status: 500 }),
+    });
     const result = await checkAndDeleteEmptyBranch(
       client,
       "owner",

--- a/test/comment-logic.test.ts
+++ b/test/comment-logic.test.ts
@@ -140,8 +140,7 @@ describe("updateCommentBody", () => {
     it("removes old branch links from body", () => {
       const input = {
         ...baseInput,
-        currentBody:
-          `Some comment with [View branch](${BRANCH_BASE_URL}/branch-name)` ,
+        currentBody: `Some comment with [View branch](${BRANCH_BASE_URL}/branch-name)`,
         branchName: "new-branch-name",
       };
 

--- a/test/gitea-server-url.test.ts
+++ b/test/gitea-server-url.test.ts
@@ -8,7 +8,7 @@ describe("GITEA_SERVER_URL configuration", () => {
     process.env = { ...originalEnv };
     delete process.env.GITEA_SERVER_URL;
     delete process.env.GITHUB_SERVER_URL;
-    
+
     // Clear module cache to force re-evaluation
     delete require.cache[require.resolve("../src/github/api/config")];
   });
@@ -61,23 +61,35 @@ describe("GITEA_SERVER_URL configuration", () => {
 
   it("should create correct job run links with custom GITEA_SERVER_URL", async () => {
     process.env.GITEA_SERVER_URL = "https://gitea.example.com";
-    
+
     // Clear module cache and re-import
-    delete require.cache[require.resolve("../src/github/operations/comments/common")];
-    const { createJobRunLink } = await import("../src/github/operations/comments/common");
-    
+    delete require.cache[
+      require.resolve("../src/github/operations/comments/common")
+    ];
+    const { createJobRunLink } = await import(
+      "../src/github/operations/comments/common"
+    );
+
     const link = createJobRunLink("owner", "repo", "123");
-    expect(link).toBe("[View job run](https://gitea.example.com/owner/repo/actions/runs/123)");
+    expect(link).toBe(
+      "[View job run](https://gitea.example.com/owner/repo/actions/runs/123)",
+    );
   });
 
   it("should create correct branch links with custom GITEA_SERVER_URL", async () => {
     process.env.GITEA_SERVER_URL = "https://gitea.example.com";
-    
+
     // Clear module cache and re-import
-    delete require.cache[require.resolve("../src/github/operations/comments/common")];
-    const { createBranchLink } = await import("../src/github/operations/comments/common");
-    
+    delete require.cache[
+      require.resolve("../src/github/operations/comments/common")
+    ];
+    const { createBranchLink } = await import(
+      "../src/github/operations/comments/common"
+    );
+
     const link = createBranchLink("owner", "repo", "feature-branch");
-    expect(link).toBe("\n[View branch](https://gitea.example.com/owner/repo/src/branch/feature-branch/)");
+    expect(link).toBe(
+      "\n[View branch](https://gitea.example.com/owner/repo/src/branch/feature-branch/)",
+    );
   });
 });

--- a/test/github-token.test.ts
+++ b/test/github-token.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import * as core from "@actions/core";
+import { setupGitHubToken } from "../src/github/token";
+
+describe("setupGitHubToken", () => {
+  const originalEnv = { ...process.env };
+  let setOutputSpy: ReturnType<typeof spyOn>;
+  let logSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    delete process.env.OVERRIDE_GITHUB_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    setOutputSpy = spyOn(core, "setOutput").mockImplementation(() => {});
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    setOutputSpy.mockRestore();
+    logSpy.mockRestore();
+    process.env = { ...originalEnv };
+  });
+
+  test("prefers the explicit Gitea token", async () => {
+    process.env.OVERRIDE_GITHUB_TOKEN = "gitea-token";
+    process.env.GITHUB_TOKEN = "workflow-token";
+
+    expect(await setupGitHubToken()).toBe("gitea-token");
+    expect(setOutputSpy).toHaveBeenCalledWith("GITHUB_TOKEN", "gitea-token");
+  });
+
+  test("falls back to the workflow token without requesting OIDC", async () => {
+    process.env.GITHUB_TOKEN = "workflow-token";
+
+    expect(await setupGitHubToken()).toBe("workflow-token");
+    expect(setOutputSpy).toHaveBeenCalledWith("GITHUB_TOKEN", "workflow-token");
+  });
+});

--- a/test/image-downloader.test.ts
+++ b/test/image-downloader.test.ts
@@ -40,7 +40,12 @@ describe("downloadCommentImages", () => {
       },
     ];
 
-    const result = await downloadCommentImages(noopClient, "owner", "repo", comments);
+    const result = await downloadCommentImages(
+      noopClient,
+      "owner",
+      "repo",
+      comments,
+    );
 
     expect(result.size).toBe(0);
     expect(consoleLogSpy).toHaveBeenCalled();

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -52,7 +52,9 @@ describe("checkWritePermissions", () => {
   });
 
   test("returns true immediately in Gitea environments", async () => {
-    const client = { api: { getBaseUrl: () => "https://gitea.example.com/api/v1" } } as any;
+    const client = {
+      api: { getBaseUrl: () => "https://gitea.example.com/api/v1" },
+    } as any;
     const result = await checkWritePermissions(client, baseContext);
 
     expect(result).toBe(true);

--- a/test/prepare-context.test.ts
+++ b/test/prepare-context.test.ts
@@ -70,11 +70,7 @@ describe("parseEnvVarsWithContext", () => {
       });
 
       test("should allow missing CLAUDE_BRANCH and omit it from event data", () => {
-        const result = prepareContext(
-          mockIssueCommentContext,
-          "12345",
-          "main",
-        );
+        const result = prepareContext(mockIssueCommentContext, "12345", "main");
 
         if (
           result.eventData.eventName === "issue_comment" &&

--- a/test/trigger-validation.test.ts
+++ b/test/trigger-validation.test.ts
@@ -417,9 +417,7 @@ describe("checkContainsTrigger", () => {
             body: "This PR fixes a bug",
             created_at: "2023-01-01T00:00:00Z",
             user: { login: "testuser" },
-            requested_reviewers: [
-              { login: "claude", id: 1, type: "User" },
-            ],
+            requested_reviewers: [{ login: "claude", id: 1, type: "User" }],
           },
         } as unknown as PullRequestEvent,
         inputs: {
@@ -491,9 +489,7 @@ describe("checkContainsTrigger", () => {
             body: "This PR fixes a bug",
             created_at: "2023-01-01T00:00:00Z",
             user: { login: "testuser" },
-            requested_reviewers: [
-              { login: "claude", id: 1, type: "User" },
-            ],
+            requested_reviewers: [{ login: "claude", id: 1, type: "User" }],
           },
         } as unknown as PullRequestEvent,
         inputs: {
@@ -516,425 +512,421 @@ describe("checkContainsTrigger", () => {
     });
   });
 
-    it("should return true when PR has trigger user as requested reviewer for synchronized event", () => {
-      const context = createMockContext({
-        eventName: "pull_request",
-        eventAction: "synchronized",
-        isPR: true,
-        payload: {
-          action: "synchronized",
-          pull_request: {
-            number: 123,
-            title: "Test PR",
-            body: "This PR fixes a bug",
-            created_at: "2023-01-01T00:00:00Z",
-            user: { login: "testuser" },
-            requested_reviewers: [
-              { login: "claude", id: 1, type: "User" },
-            ],
-            requested_teams: [],
-          },
-        } as unknown as PullRequestEvent,
-        inputs: {
-          mode: "tag",
-          triggerPhrase: "@claude",
-          assigneeTrigger: "",
-          labelTrigger: "",
-          directPrompt: "",
-          overridePrompt: "",
-          allowedTools: [],
-          disallowedTools: [],
-          customInstructions: "",
-          branchPrefix: "claude/",
-          useStickyComment: false,
-          additionalPermissions: new Map(),
-          useCommitSigning: false,
+  it("should return true when PR has trigger user as requested reviewer for synchronized event", () => {
+    const context = createMockContext({
+      eventName: "pull_request",
+      eventAction: "synchronized",
+      isPR: true,
+      payload: {
+        action: "synchronized",
+        pull_request: {
+          number: 123,
+          title: "Test PR",
+          body: "This PR fixes a bug",
+          created_at: "2023-01-01T00:00:00Z",
+          user: { login: "testuser" },
+          requested_reviewers: [{ login: "claude", id: 1, type: "User" }],
+          requested_teams: [],
         },
-      });
-      expect(checkContainsTrigger(context)).toBe(true);
+      } as unknown as PullRequestEvent,
+      inputs: {
+        mode: "tag",
+        triggerPhrase: "@claude",
+        assigneeTrigger: "",
+        labelTrigger: "",
+        directPrompt: "",
+        overridePrompt: "",
+        allowedTools: [],
+        disallowedTools: [],
+        customInstructions: "",
+        branchPrefix: "claude/",
+        useStickyComment: false,
+        additionalPermissions: new Map(),
+        useCommitSigning: false,
+      },
     });
-
-    it("should return false when PR has no matching requested reviewers", () => {
-      const context = createMockContext({
-        eventName: "pull_request",
-        eventAction: "opened",
-        isPR: true,
-        payload: {
-          action: "opened",
-          pull_request: {
-            number: 123,
-            title: "Test PR",
-            body: "This PR fixes a bug",
-            created_at: "2023-01-01T00:00:00Z",
-            user: { login: "testuser" },
-            requested_reviewers: [
-              { login: "other-reviewer", id: 2, type: "User" },
-            ],
-            requested_teams: [],
-          },
-        } as unknown as PullRequestEvent,
-        inputs: {
-          mode: "tag",
-          triggerPhrase: "@claude",
-          assigneeTrigger: "",
-          labelTrigger: "",
-          directPrompt: "",
-          overridePrompt: "",
-          allowedTools: [],
-          disallowedTools: [],
-          customInstructions: "",
-          branchPrefix: "claude/",
-          useStickyComment: false,
-          additionalPermissions: new Map(),
-          useCommitSigning: false,
-        },
-      });
-      expect(checkContainsTrigger(context)).toBe(false);
-    });
-
-    it("should handle trigger phrase without @ symbol", () => {
-      const context = createMockContext({
-        eventName: "pull_request",
-        eventAction: "opened",
-        isPR: true,
-        payload: {
-          action: "opened",
-          pull_request: {
-            number: 123,
-            title: "Test PR",
-            body: "This PR fixes a bug",
-            created_at: "2023-01-01T00:00:00Z",
-            user: { login: "testuser" },
-            requested_reviewers: [
-              { login: "claude", id: 1, type: "User" },
-            ],
-            requested_teams: [],
-          },
-        } as unknown as PullRequestEvent,
-        inputs: {
-          mode: "tag",
-          triggerPhrase: "claude", // No @ symbol
-          assigneeTrigger: "",
-          labelTrigger: "",
-          directPrompt: "",
-          overridePrompt: "",
-          allowedTools: [],
-          disallowedTools: [],
-          customInstructions: "",
-          branchPrefix: "claude/",
-          useStickyComment: false,
-          additionalPermissions: new Map(),
-          useCommitSigning: false,
-        },
-      });
-      expect(checkContainsTrigger(context)).toBe(true);
-    });
-
-    it("should handle empty requested_reviewers and requested_teams arrays", () => {
-      const context = createMockContext({
-        eventName: "pull_request",
-        eventAction: "opened",
-        isPR: true,
-        payload: {
-          action: "opened",
-          pull_request: {
-            number: 123,
-            title: "Test PR",
-            body: "This PR fixes a bug",
-            created_at: "2023-01-01T00:00:00Z",
-            user: { login: "testuser" },
-            requested_reviewers: [],
-            requested_teams: [],
-          },
-        } as unknown as PullRequestEvent,
-        inputs: {
-          mode: "tag",
-          triggerPhrase: "@claude",
-          assigneeTrigger: "",
-          labelTrigger: "",
-          directPrompt: "",
-          overridePrompt: "",
-          allowedTools: [],
-          disallowedTools: [],
-          customInstructions: "",
-          branchPrefix: "claude/",
-          useStickyComment: false,
-          additionalPermissions: new Map(),
-          useCommitSigning: false,
-        },
-      });
-      expect(checkContainsTrigger(context)).toBe(false);
-    });
-
-    it("should handle missing requested_reviewers and requested_teams fields", () => {
-      const context = createMockContext({
-        eventName: "pull_request",
-        eventAction: "opened",
-        isPR: true,
-        payload: {
-          action: "opened",
-          pull_request: {
-            number: 123,
-            title: "Test PR",
-            body: "This PR fixes a bug",
-            created_at: "2023-01-01T00:00:00Z",
-            user: { login: "testuser" },
-            // requested_reviewers and requested_teams are undefined
-          },
-        } as unknown as PullRequestEvent,
-        inputs: {
-          mode: "tag",
-          triggerPhrase: "@claude",
-          assigneeTrigger: "",
-          labelTrigger: "",
-          directPrompt: "",
-          overridePrompt: "",
-          allowedTools: [],
-          disallowedTools: [],
-          customInstructions: "",
-          branchPrefix: "claude/",
-          useStickyComment: false,
-          additionalPermissions: new Map(),
-          useCommitSigning: false,
-        },
-      });
-      expect(checkContainsTrigger(context)).toBe(false);
-    });
+    expect(checkContainsTrigger(context)).toBe(true);
   });
 
-  describe("comment trigger", () => {
-    it("should return true for issue_comment with trigger phrase", () => {
-      const context = mockIssueCommentContext;
-      expect(checkContainsTrigger(context)).toBe(true);
-    });
-
-    it("should return true for pull_request_review_comment with trigger phrase", () => {
-      const context = mockPullRequestReviewCommentContext;
-      expect(checkContainsTrigger(context)).toBe(true);
-    });
-
-    it("should return true for pull_request_review with submitted action and trigger phrase", () => {
-      const context = mockPullRequestReviewContext;
-      expect(checkContainsTrigger(context)).toBe(true);
-    });
-
-    it("should return true for pull_request_review with edited action and trigger phrase", () => {
-      const context = {
-        ...mockPullRequestReviewContext,
-        eventAction: "edited",
-        payload: {
-          ...mockPullRequestReviewContext.payload,
-          action: "edited",
+  it("should return false when PR has no matching requested reviewers", () => {
+    const context = createMockContext({
+      eventName: "pull_request",
+      eventAction: "opened",
+      isPR: true,
+      payload: {
+        action: "opened",
+        pull_request: {
+          number: 123,
+          title: "Test PR",
+          body: "This PR fixes a bug",
+          created_at: "2023-01-01T00:00:00Z",
+          user: { login: "testuser" },
+          requested_reviewers: [
+            { login: "other-reviewer", id: 2, type: "User" },
+          ],
+          requested_teams: [],
         },
-      } as ParsedGitHubContext;
-      expect(checkContainsTrigger(context)).toBe(true);
+      } as unknown as PullRequestEvent,
+      inputs: {
+        mode: "tag",
+        triggerPhrase: "@claude",
+        assigneeTrigger: "",
+        labelTrigger: "",
+        directPrompt: "",
+        overridePrompt: "",
+        allowedTools: [],
+        disallowedTools: [],
+        customInstructions: "",
+        branchPrefix: "claude/",
+        useStickyComment: false,
+        additionalPermissions: new Map(),
+        useCommitSigning: false,
+      },
     });
+    expect(checkContainsTrigger(context)).toBe(false);
+  });
 
-    it("should return false for pull_request_review with different action", () => {
+  it("should handle trigger phrase without @ symbol", () => {
+    const context = createMockContext({
+      eventName: "pull_request",
+      eventAction: "opened",
+      isPR: true,
+      payload: {
+        action: "opened",
+        pull_request: {
+          number: 123,
+          title: "Test PR",
+          body: "This PR fixes a bug",
+          created_at: "2023-01-01T00:00:00Z",
+          user: { login: "testuser" },
+          requested_reviewers: [{ login: "claude", id: 1, type: "User" }],
+          requested_teams: [],
+        },
+      } as unknown as PullRequestEvent,
+      inputs: {
+        mode: "tag",
+        triggerPhrase: "claude", // No @ symbol
+        assigneeTrigger: "",
+        labelTrigger: "",
+        directPrompt: "",
+        overridePrompt: "",
+        allowedTools: [],
+        disallowedTools: [],
+        customInstructions: "",
+        branchPrefix: "claude/",
+        useStickyComment: false,
+        additionalPermissions: new Map(),
+        useCommitSigning: false,
+      },
+    });
+    expect(checkContainsTrigger(context)).toBe(true);
+  });
+
+  it("should handle empty requested_reviewers and requested_teams arrays", () => {
+    const context = createMockContext({
+      eventName: "pull_request",
+      eventAction: "opened",
+      isPR: true,
+      payload: {
+        action: "opened",
+        pull_request: {
+          number: 123,
+          title: "Test PR",
+          body: "This PR fixes a bug",
+          created_at: "2023-01-01T00:00:00Z",
+          user: { login: "testuser" },
+          requested_reviewers: [],
+          requested_teams: [],
+        },
+      } as unknown as PullRequestEvent,
+      inputs: {
+        mode: "tag",
+        triggerPhrase: "@claude",
+        assigneeTrigger: "",
+        labelTrigger: "",
+        directPrompt: "",
+        overridePrompt: "",
+        allowedTools: [],
+        disallowedTools: [],
+        customInstructions: "",
+        branchPrefix: "claude/",
+        useStickyComment: false,
+        additionalPermissions: new Map(),
+        useCommitSigning: false,
+      },
+    });
+    expect(checkContainsTrigger(context)).toBe(false);
+  });
+
+  it("should handle missing requested_reviewers and requested_teams fields", () => {
+    const context = createMockContext({
+      eventName: "pull_request",
+      eventAction: "opened",
+      isPR: true,
+      payload: {
+        action: "opened",
+        pull_request: {
+          number: 123,
+          title: "Test PR",
+          body: "This PR fixes a bug",
+          created_at: "2023-01-01T00:00:00Z",
+          user: { login: "testuser" },
+          // requested_reviewers and requested_teams are undefined
+        },
+      } as unknown as PullRequestEvent,
+      inputs: {
+        mode: "tag",
+        triggerPhrase: "@claude",
+        assigneeTrigger: "",
+        labelTrigger: "",
+        directPrompt: "",
+        overridePrompt: "",
+        allowedTools: [],
+        disallowedTools: [],
+        customInstructions: "",
+        branchPrefix: "claude/",
+        useStickyComment: false,
+        additionalPermissions: new Map(),
+        useCommitSigning: false,
+      },
+    });
+    expect(checkContainsTrigger(context)).toBe(false);
+  });
+});
+
+describe("comment trigger", () => {
+  it("should return true for issue_comment with trigger phrase", () => {
+    const context = mockIssueCommentContext;
+    expect(checkContainsTrigger(context)).toBe(true);
+  });
+
+  it("should return true for pull_request_review_comment with trigger phrase", () => {
+    const context = mockPullRequestReviewCommentContext;
+    expect(checkContainsTrigger(context)).toBe(true);
+  });
+
+  it("should return true for pull_request_review with submitted action and trigger phrase", () => {
+    const context = mockPullRequestReviewContext;
+    expect(checkContainsTrigger(context)).toBe(true);
+  });
+
+  it("should return true for pull_request_review with edited action and trigger phrase", () => {
+    const context = {
+      ...mockPullRequestReviewContext,
+      eventAction: "edited",
+      payload: {
+        ...mockPullRequestReviewContext.payload,
+        action: "edited",
+      },
+    } as ParsedGitHubContext;
+    expect(checkContainsTrigger(context)).toBe(true);
+  });
+
+  it("should return false for pull_request_review with different action", () => {
+    const context = {
+      ...mockPullRequestReviewContext,
+      eventAction: "dismissed",
+      payload: {
+        ...mockPullRequestReviewContext.payload,
+        action: "dismissed",
+        review: {
+          ...(mockPullRequestReviewContext.payload as PullRequestReviewEvent)
+            .review,
+          body: "/claude please review this PR",
+        },
+      },
+    } as ParsedGitHubContext;
+    expect(checkContainsTrigger(context)).toBe(false);
+  });
+
+  it("should handle pull_request_review with punctuation", () => {
+    const baseContext = {
+      ...mockPullRequestReviewContext,
+      inputs: {
+        ...mockPullRequestReviewContext.inputs,
+        triggerPhrase: "@claude",
+      },
+    };
+
+    const testCases = [
+      { commentBody: "@claude, please review", expected: true },
+      { commentBody: "@claude. fix this", expected: true },
+      { commentBody: "@claude!", expected: true },
+      { commentBody: "claude@example.com", expected: false },
+      { commentBody: "claudette", expected: false },
+    ];
+
+    testCases.forEach(({ commentBody, expected }) => {
       const context = {
-        ...mockPullRequestReviewContext,
-        eventAction: "dismissed",
+        ...baseContext,
         payload: {
-          ...mockPullRequestReviewContext.payload,
-          action: "dismissed",
+          ...baseContext.payload,
           review: {
-            ...(mockPullRequestReviewContext.payload as PullRequestReviewEvent)
-              .review,
-            body: "/claude please review this PR",
+            ...(baseContext.payload as PullRequestReviewEvent).review,
+            body: commentBody,
           },
         },
       } as ParsedGitHubContext;
-      expect(checkContainsTrigger(context)).toBe(false);
-    });
-
-    it("should handle pull_request_review with punctuation", () => {
-      const baseContext = {
-        ...mockPullRequestReviewContext,
-        inputs: {
-          ...mockPullRequestReviewContext.inputs,
-          triggerPhrase: "@claude",
-        },
-      };
-
-      const testCases = [
-        { commentBody: "@claude, please review", expected: true },
-        { commentBody: "@claude. fix this", expected: true },
-        { commentBody: "@claude!", expected: true },
-        { commentBody: "claude@example.com", expected: false },
-        { commentBody: "claudette", expected: false },
-      ];
-
-      testCases.forEach(({ commentBody, expected }) => {
-        const context = {
-          ...baseContext,
-          payload: {
-            ...baseContext.payload,
-            review: {
-              ...(baseContext.payload as PullRequestReviewEvent).review,
-              body: commentBody,
-            },
-          },
-        } as ParsedGitHubContext;
-        expect(checkContainsTrigger(context)).toBe(expected);
-      });
-    });
-
-    it("should handle comment trigger with punctuation", () => {
-      const baseContext = {
-        ...mockIssueCommentContext,
-        inputs: {
-          ...mockIssueCommentContext.inputs,
-          triggerPhrase: "@claude",
-        },
-      };
-
-      const testCases = [
-        { commentBody: "@claude, please review", expected: true },
-        { commentBody: "@claude. fix this", expected: true },
-        { commentBody: "@claude!", expected: true },
-        { commentBody: "claude@example.com", expected: false },
-        { commentBody: "claudette", expected: false },
-      ];
-
-      testCases.forEach(({ commentBody, expected }) => {
-        const context = {
-          ...baseContext,
-          payload: {
-            ...baseContext.payload,
-            comment: {
-              ...(baseContext.payload as IssueCommentEvent).comment,
-              body: commentBody,
-            },
-          },
-        } as ParsedGitHubContext;
-        expect(checkContainsTrigger(context)).toBe(expected);
-      });
+      expect(checkContainsTrigger(context)).toBe(expected);
     });
   });
 
-  describe("pull request review_requested action", () => {
-    it("should return true when trigger user is requested as reviewer", () => {
-      const context = createMockContext({
-        eventName: "pull_request",
-        eventAction: "review_requested",
-        isPR: true,
-        payload: {
-          action: "review_requested",
-          pull_request: {
-            number: 123,
-            title: "Test PR",
-            body: "This PR fixes a bug",
-            created_at: "2023-01-01T00:00:00Z",
-            user: { login: "testuser" },
-            requested_reviewers: [{ login: "claude", id: 1, type: "User" }],
-            requested_teams: [],
-          },
-          requested_reviewer: { login: "claude", id: 1, type: "User" },
-        } as unknown as PullRequestEvent,
-        inputs: {
-          mode: "tag",
-          triggerPhrase: "@claude",
-          assigneeTrigger: "",
-          labelTrigger: "",
-          directPrompt: "",
-          overridePrompt: "",
-          allowedTools: [],
-          disallowedTools: [],
-          customInstructions: "",
-          branchPrefix: "claude/",
-          useStickyComment: false,
-          additionalPermissions: new Map(),
-          useCommitSigning: false,
-        },
-      });
-      expect(checkContainsTrigger(context)).toBe(true);
-    });
+  it("should handle comment trigger with punctuation", () => {
+    const baseContext = {
+      ...mockIssueCommentContext,
+      inputs: {
+        ...mockIssueCommentContext.inputs,
+        triggerPhrase: "@claude",
+      },
+    };
 
-    it("should return false when different user is requested as reviewer", () => {
-      const context = createMockContext({
-        eventName: "pull_request",
-        eventAction: "review_requested",
-        isPR: true,
-        payload: {
-          action: "review_requested",
-          pull_request: {
-            number: 123,
-            title: "Test PR",
-            body: "This PR fixes a bug",
-            created_at: "2023-01-01T00:00:00Z",
-            user: { login: "testuser" },
-            requested_reviewers: [{ login: "john", id: 2, type: "User" }],
-            requested_teams: [],
-          },
-          requested_reviewer: { login: "john", id: 2, type: "User" },
-        } as unknown as PullRequestEvent,
-        inputs: {
-          mode: "tag",
-          triggerPhrase: "@claude",
-          assigneeTrigger: "",
-          labelTrigger: "",
-          directPrompt: "",
-          overridePrompt: "",
-          allowedTools: [],
-          disallowedTools: [],
-          customInstructions: "",
-          branchPrefix: "claude/",
-          useStickyComment: false,
-          additionalPermissions: new Map(),
-          useCommitSigning: false,
-        },
-      });
-      expect(checkContainsTrigger(context)).toBe(false);
-    });
+    const testCases = [
+      { commentBody: "@claude, please review", expected: true },
+      { commentBody: "@claude. fix this", expected: true },
+      { commentBody: "@claude!", expected: true },
+      { commentBody: "claude@example.com", expected: false },
+      { commentBody: "claudette", expected: false },
+    ];
 
-    it("should handle trigger phrase without @ symbol", () => {
-      const context = createMockContext({
-        eventName: "pull_request",
-        eventAction: "review_requested",
-        isPR: true,
+    testCases.forEach(({ commentBody, expected }) => {
+      const context = {
+        ...baseContext,
         payload: {
-          action: "review_requested",
-          pull_request: {
-            number: 123,
-            title: "Test PR",
-            body: "This PR fixes a bug",
-            created_at: "2023-01-01T00:00:00Z",
-            user: { login: "testuser" },
-            requested_reviewers: [{ login: "claude", id: 1, type: "User" }],
-            requested_teams: [],
+          ...baseContext.payload,
+          comment: {
+            ...(baseContext.payload as IssueCommentEvent).comment,
+            body: commentBody,
           },
-          requested_reviewer: { login: "claude", id: 1, type: "User" },
-        } as unknown as PullRequestEvent,
-        inputs: {
-          mode: "tag",
-          triggerPhrase: "claude", // no @ symbol
-          assigneeTrigger: "",
-          labelTrigger: "",
-          directPrompt: "",
-          overridePrompt: "",
-          allowedTools: [],
-          disallowedTools: [],
-          customInstructions: "",
-          branchPrefix: "claude/",
-          useStickyComment: false,
-          additionalPermissions: new Map(),
-          useCommitSigning: false,
         },
-      });
-      expect(checkContainsTrigger(context)).toBe(true);
+      } as ParsedGitHubContext;
+      expect(checkContainsTrigger(context)).toBe(expected);
     });
   });
+});
 
-  describe("non-matching events", () => {
-    it("should return false for non-matching event type", () => {
-      const context = createMockContext({
-        eventName: "push",
-        eventAction: "created",
-        payload: {} as any,
-      });
-      expect(checkContainsTrigger(context)).toBe(false);
+describe("pull request review_requested action", () => {
+  it("should return true when trigger user is requested as reviewer", () => {
+    const context = createMockContext({
+      eventName: "pull_request",
+      eventAction: "review_requested",
+      isPR: true,
+      payload: {
+        action: "review_requested",
+        pull_request: {
+          number: 123,
+          title: "Test PR",
+          body: "This PR fixes a bug",
+          created_at: "2023-01-01T00:00:00Z",
+          user: { login: "testuser" },
+          requested_reviewers: [{ login: "claude", id: 1, type: "User" }],
+          requested_teams: [],
+        },
+        requested_reviewer: { login: "claude", id: 1, type: "User" },
+      } as unknown as PullRequestEvent,
+      inputs: {
+        mode: "tag",
+        triggerPhrase: "@claude",
+        assigneeTrigger: "",
+        labelTrigger: "",
+        directPrompt: "",
+        overridePrompt: "",
+        allowedTools: [],
+        disallowedTools: [],
+        customInstructions: "",
+        branchPrefix: "claude/",
+        useStickyComment: false,
+        additionalPermissions: new Map(),
+        useCommitSigning: false,
+      },
     });
+    expect(checkContainsTrigger(context)).toBe(true);
   });
+
+  it("should return false when different user is requested as reviewer", () => {
+    const context = createMockContext({
+      eventName: "pull_request",
+      eventAction: "review_requested",
+      isPR: true,
+      payload: {
+        action: "review_requested",
+        pull_request: {
+          number: 123,
+          title: "Test PR",
+          body: "This PR fixes a bug",
+          created_at: "2023-01-01T00:00:00Z",
+          user: { login: "testuser" },
+          requested_reviewers: [{ login: "john", id: 2, type: "User" }],
+          requested_teams: [],
+        },
+        requested_reviewer: { login: "john", id: 2, type: "User" },
+      } as unknown as PullRequestEvent,
+      inputs: {
+        mode: "tag",
+        triggerPhrase: "@claude",
+        assigneeTrigger: "",
+        labelTrigger: "",
+        directPrompt: "",
+        overridePrompt: "",
+        allowedTools: [],
+        disallowedTools: [],
+        customInstructions: "",
+        branchPrefix: "claude/",
+        useStickyComment: false,
+        additionalPermissions: new Map(),
+        useCommitSigning: false,
+      },
+    });
+    expect(checkContainsTrigger(context)).toBe(false);
+  });
+
+  it("should handle trigger phrase without @ symbol", () => {
+    const context = createMockContext({
+      eventName: "pull_request",
+      eventAction: "review_requested",
+      isPR: true,
+      payload: {
+        action: "review_requested",
+        pull_request: {
+          number: 123,
+          title: "Test PR",
+          body: "This PR fixes a bug",
+          created_at: "2023-01-01T00:00:00Z",
+          user: { login: "testuser" },
+          requested_reviewers: [{ login: "claude", id: 1, type: "User" }],
+          requested_teams: [],
+        },
+        requested_reviewer: { login: "claude", id: 1, type: "User" },
+      } as unknown as PullRequestEvent,
+      inputs: {
+        mode: "tag",
+        triggerPhrase: "claude", // no @ symbol
+        assigneeTrigger: "",
+        labelTrigger: "",
+        directPrompt: "",
+        overridePrompt: "",
+        allowedTools: [],
+        disallowedTools: [],
+        customInstructions: "",
+        branchPrefix: "claude/",
+        useStickyComment: false,
+        additionalPermissions: new Map(),
+        useCommitSigning: false,
+      },
+    });
+    expect(checkContainsTrigger(context)).toBe(true);
+  });
+});
+
+describe("non-matching events", () => {
+  it("should return false for non-matching event type", () => {
+    const context = createMockContext({
+      eventName: "push",
+      eventAction: "created",
+      payload: {} as any,
+    });
+    expect(checkContainsTrigger(context)).toBe(false);
+  });
+});
 
 describe("escapeRegExp", () => {
   it("should escape special regex characters", () => {


### PR DESCRIPTION
## Summary
- Update the default installed Claude Code version from `1.0.127` to `2.1.173` in `action.yml` and `base-action/action.yml`.
- Pass `CLAUDE_CODE_OAUTH_TOKEN` through the dedicated `claude_code_oauth_token` workflow input so CI can authenticate when `ANTHROPIC_API_KEY` is not configured.

## Why
Keeps both GitHub Action entry points aligned to the latest pinned Claude Code version and lets the repository workflows use the configured OAuth token secret.
